### PR TITLE
fix: Fix API handling of media data paths

### DIFF
--- a/src/Controllers/Api/MiscCtrl.php
+++ b/src/Controllers/Api/MiscCtrl.php
@@ -1425,7 +1425,7 @@ class MiscCtrl
                 $domainFilterPub    = \App\Models\StatusModel::domainBlockSql('s.user_id', $blockedDomainsPub);
                 $pubUserId = $user['id'] ?? '';
                 $mediaOnly = in_array($stream, ['public:media', 'public:local:media'], true);
-                $mediaClause = $mediaOnly ? ' AND EXISTS (SELECT 1 FROM media_attachments ma WHERE ma.status_id = s.id)' : '';
+                $mediaClause = $mediaOnly ? ' AND EXISTS (SELECT 1 FROM status_media sm WHERE sm.status_id = s.id)' : '';
                 if (in_array($stream, ['public:local', 'public:local:media'], true)) {
                     $rows = \App\Models\DB::all(
                         "SELECT s.* FROM statuses s WHERE s.visibility='public' AND s.local=1

--- a/src/Models/MediaModel.php
+++ b/src/Models/MediaModel.php
@@ -117,8 +117,13 @@ class MediaModel
 
     public static function toMasto(array $m): array
     {
-        $w = $m['width']  ? (int)$m['width']  : null;
-        $h = $m['height'] ? (int)$m['height'] : null;
+        $w = !empty($m['width'])  ? (int)$m['width']  : null;
+        $h = !empty($m['height']) ? (int)$m['height'] : null;
+        $url = (string)($m['url'] ?? '');
+        $previewUrl = (string)($m['preview_url'] ?? '');
+        if ($previewUrl === '') {
+            $previewUrl = $url;
+        }
 
         $meta = ($w && $h)
             ? ['original' => ['width' => $w, 'height' => $h, 'aspect' => round($w / $h, 4)],
@@ -128,27 +133,27 @@ class MediaModel
         $remoteUrl = null;
         if (!empty($m['remote_url'])) {
             $remoteUrl = $m['remote_url'];
-        } elseif (!empty($m['original_url']) && ($m['original_url'] ?? '') !== ($m['url'] ?? '')) {
+        } elseif (!empty($m['original_url']) && (string)$m['original_url'] !== $url) {
             $remoteUrl = $m['original_url'];
         }
 
         $previewRemoteUrl = null;
         if (!empty($m['preview_remote_url'])) {
             $previewRemoteUrl = $m['preview_remote_url'];
-        } elseif (!empty($m['original_preview_url']) && ($m['original_preview_url'] ?? '') !== ($m['preview_url'] ?? '')) {
+        } elseif (!empty($m['original_preview_url']) && (string)$m['original_preview_url'] !== $previewUrl) {
             $previewRemoteUrl = $m['original_preview_url'];
         }
 
         return [
-            'id'                 => $m['id'],
-            'type'               => $m['type'],
-            'url'                => $m['url'],
-            'preview_url'        => $m['preview_url'],
+            'id'                 => (string)($m['id'] ?? ''),
+            'type'               => (string)($m['type'] ?? 'unknown'),
+            'url'                => $url,
+            'preview_url'        => $previewUrl,
             'remote_url'         => $remoteUrl,
             'preview_remote_url' => $previewRemoteUrl,
             'text_url'           => null,
             'description'        => $m['description'] ?? '',
-            'blurhash'           => $m['blurhash'] ?: null,
+            'blurhash'           => !empty($m['blurhash']) ? $m['blurhash'] : null,
             'meta'               => $meta,
         ];
     }


### PR DESCRIPTION
fix: Fix API handling of media data paths
  The web interface uses status_media to find
  attachments, but one Mastodon API streaming
  media path was checking media_attachments.status_id
  instead. Remote media is often linked only through
  status_media, so clients could miss media while
  the web UI showed it correctly.

This issue only comes up when using third-party clients which rely on the API. So, I streamlined it to the same behavior like the built-in web interface.